### PR TITLE
Use original file if chunk size is 1

### DIFF
--- a/default.php
+++ b/default.php
@@ -257,8 +257,12 @@ class Consolidate extends Gdn_Plugin {
       $ChunkedFilesTemp = $this->ChunkedFiles;
       $ChunkedCss = $this->_Chunk($CssToCache, '.css');
       foreach($ChunkedCss As $CssChunkGroup => $CssChunk){
-        $Token = $this->_Consolidate($CssChunk, '.css', $CssChunkGroup);
-        $Head->AddCss("/cache/Consolidate/$Token", 'screen', FALSE);
+        if(count($CssChunk)==1) {
+          $Head->AddCss('/'.$CssChunk[0]['href'], 'screen', true);
+        } else {
+          $Token = $this->_Consolidate($CssChunk, '.css', $CssChunkGroup);
+          $Head->AddCss("/cache/Consolidate/$Token", 'screen', FALSE);
+        }
       }
       $Head = $this->_SeperateInlineScripts($Head);
       Gdn::Controller()->Assets['Head'] = $Head;


### PR DESCRIPTION
If there is only one file in a chunk, then we do not need to consolidate this single file. Instead, the original file can be included.

I've realized this idea in this pull request for CSS only. Of course, this can be also realized for JavaScript. However, here is a special treatment required for DeferJS, if active.
