### PR TITLE
Do not enforce .* chunk

### DIFF
--- a/default.php
+++ b/default.php
@@ -413,7 +413,8 @@ class Consolidate extends Gdn_Plugin {
                }
            }
            if(!$found) {
-               $ChunkedFiles[$File['href']][] = $File;
+               $NiceKey = trim(Gdn_Format::Url(preg_replace('`[^a-z0-9]+`i','_',$File['href'])),'_').'_';
+               $ChunkedFiles[$NiceKey][] = $File;
            }
        }
        

--- a/default.php
+++ b/default.php
@@ -144,8 +144,8 @@ class Consolidate extends Gdn_Plugin {
                 $I = array_search('.*',$ChunkGroups[$Ext]);
                 if($I > -1){
                     unset($ChunkGroups[$Ext][$I]);
+                    $ChunkGroups[$Ext][] = '.*';
                 }
-                $ChunkGroups[$Ext][] = '.*';
             } 
             SaveToConfig('Plugins.Consolidate.DeferJs',GetValue('DeferJs',$FormValues) ? TRUE : FALSE);
             if(!empty($ChunkGroups)){
@@ -399,15 +399,21 @@ class Consolidate extends Gdn_Plugin {
        if(empty($Chunks))
             return array(Gdn_Format::Url('.*')=>$Files);
        $ChunkedFiles = array();
-       foreach($Chunks As $Chunk){
-           foreach($Files As $FileIndex => $File){
+       foreach($Files As $FileIndex => $File){
+           $found = false;
+           foreach($Chunks As $Chunk){
                if(preg_match('`^'.$Chunk.'`', $File['href'])){
                    $NiceKey = trim(Gdn_Format::Url(preg_replace('`[^a-z0-9]+`i','_',$Chunk)),'_').'_';
                    if(!GetValue($NiceKey,$ChunkedFile))
                         $ChunkedFile[$NiceKey] = array();
                    $ChunkedFiles[$NiceKey][] = $File;
                    unset($Files[$FileIndex]);
+                   $found = true;
+                   break;
                }
+           }
+           if(!$found) {
+               $ChunkedFiles[$File['href']][] = $File;
            }
        }
        


### PR DESCRIPTION
I like the approach of this plugin. However, it has one disadvantage. In practice, the set of JS and CSS files differ for different page request since different controllers process the request. However, there is a "base set" which doesn't change. For this base set, I create a PCRE pattern. The other composition of the remaining files differ heavily, so it often doesn't make any sense to consolidate them. Example:

request A => JS files A B C D E
request B => JS files A B C E F
request C => JS files A B C G

Assume that file E is relatively large. If we consolidate them using the base set A,B,C, we get:

request A => JS files C1 C2
request B => JS files C1 C3
request C => JS files C1 C4

The files C2 and C3 are very large and loading the page slows down, although file E could have been cached. In order to have more control about which files should be consolidated, I propose to do not enforce a `.*` chunk.

Now, I can define the PCRE pattern (A|B|C) and get:

request A => JS files C1 D E
request B => JS files C1 E F
request C => JS files C1 G

Yes, I have more requests than before, but the client is able to cache file E! I think, there are many scenarios, where this is important and I do not to check for large files and make extra rules for them. Nevertheless, I can still add an `.*` pattern at the end -- if I want.
